### PR TITLE
Ensure detection will only be done on `http-equiv="Content-Type"` 

### DIFF
--- a/source/utils/get-charset.ts
+++ b/source/utils/get-charset.ts
@@ -28,7 +28,7 @@ export default function getCharset(content: Buffer, headers?: Headers) {
 
 		charset = parseContentType(
 			$('meta[charset]').attr('charset') // HTML5
-			|| $('meta[http-equiv=Content-Type][content]').attr('content') // HTML4
+			|| parseContentType($('meta[http-equiv="Content-Type"][content]').attr('content')) // HTML4
 			|| load(data.replace(/<\?(.*)\?>/im, '<$1>'), {xmlMode: true}).root().find('xml').attr('encoding'), // XML
 		);
 


### PR DESCRIPTION
Avoid trying to guess charset from `http-equiv="X-UA-Compatible"`